### PR TITLE
fix: 동료 조회 API 수정

### DIFF
--- a/src/main/java/com/example/main_server/evaluation/common/dto/TaskInfoResponse.java
+++ b/src/main/java/com/example/main_server/evaluation/common/dto/TaskInfoResponse.java
@@ -1,0 +1,5 @@
+package com.example.main_server.evaluation.common.dto;
+
+public record TaskInfoResponse(Long taskId, String taskName) {
+}
+

--- a/src/main/java/com/example/main_server/evaluation/common/repository/TaskParticipationRepository.java
+++ b/src/main/java/com/example/main_server/evaluation/common/repository/TaskParticipationRepository.java
@@ -1,5 +1,6 @@
 package com.example.main_server.evaluation.common.repository;
 
+import com.example.main_server.evaluation.common.entity.Task;
 import com.example.main_server.evaluation.common.entity.TaskParticipation;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +18,10 @@ public interface TaskParticipationRepository extends JpaRepository<TaskParticipa
     @Query("SELECT tp FROM TaskParticipation tp WHERE tp.task.id = :taskId AND tp.user.id != :excludeUserId")
     List<TaskParticipation> findByTaskIdAndUserIdNot(@Param("taskId") Long taskId,
                                                      @Param("excludeUserId") Long excludeUserId);
+
+    // 두 사용자가 함께 참여한 모든 Task 조회
+    @Query("SELECT DISTINCT tp1.task FROM TaskParticipation tp1 " +
+            "JOIN TaskParticipation tp2 ON tp1.task.id = tp2.task.id " +
+            "WHERE tp1.user.id = :userId1 AND tp2.user.id = :userId2")
+    List<Task> findCommonTasksByUserIds(@Param("userId1") Long userId1, @Param("userId2") Long userId2);
 }

--- a/src/main/java/com/example/main_server/evaluation/peer/dto/PeerInfoResponse.java
+++ b/src/main/java/com/example/main_server/evaluation/peer/dto/PeerInfoResponse.java
@@ -1,4 +1,8 @@
 package com.example.main_server.evaluation.peer.dto;
 
-public record PeerInfoResponse(Long userId, String name) {
+import com.example.main_server.evaluation.common.dto.TaskInfoResponse;
+import java.util.List;
+
+public record PeerInfoResponse(Long userId, String name, List<TaskInfoResponse> task) {
 }
+


### PR DESCRIPTION
### **User description**
- 같이 한 Task 값도 API 응답값에 적용

```json
[
  {
    "userId": 1,
    "name": "홍길동",
    "task":[
	    {
		    "taskId":1,
		    "taskName":"A프로젝트"
	    },
	    {
		    "taskId":2,
		    "taskName":"B프로젝트"
	    }
    ]
  },
  {
    "userId": 2,
    "name": "김철수",
    "task":[
	    {
		    "taskId":3,
		    "taskName":"C프로젝트"
	    }
    ]
  },
]
```


___

### **PR Type**
enhancement


___

### **Description**
- 동료 조회 API에 공통 Task 정보 추가

- `TaskInfoResponse` 클래스 생성

- `PeerInfoResponse`에 Task 정보 필드 추가

- 두 사용자가 함께 참여한 Task 조회 기능 추가


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TaskInfoResponse.java</strong><dd><code>Task 정보 응답을 위한 클래스 생성</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/example/main_server/evaluation/common/dto/TaskInfoResponse.java

- `TaskInfoResponse` 클래스 생성
- Task ID와 이름을 포함하는 레코드


</details>


  </td>
  <td><a href="https://github.com/LEADME-skala5/main_back_server/pull/9/files#diff-78634019c6d38f1d96ced573accb85d9dc31bb8d0e653bcf4a19eee9cb09fad4">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TaskParticipationRepository.java</strong><dd><code>공통 Task 조회 메서드 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/example/main_server/evaluation/common/repository/TaskParticipationRepository.java

- 두 사용자가 함께 참여한 Task 조회 메서드 추가
- `Task` 엔티티 임포트 추가


</details>


  </td>
  <td><a href="https://github.com/LEADME-skala5/main_back_server/pull/9/files#diff-4c02b218f902c7dde008628c662f6d11305b757a94247a78edaf6512fe513fbf">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PeerEvaluationService.java</strong><dd><code>동료 조회 시 공통 Task 정보 포함</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/example/main_server/evaluation/peer/PeerEvaluationService.java

<li>동료 조회 시 공통 Task 정보 수집<br> <li> <code>PeerInfoResponse</code>에 Task 정보 추가<br> <li> 중복 제거된 동료 목록 생성


</details>


  </td>
  <td><a href="https://github.com/LEADME-skala5/main_back_server/pull/9/files#diff-846716c44eae2d5b957b0621d3f1f67b3107ec714eaa82f10b42104244f75080">+40/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PeerInfoResponse.java</strong><dd><code>Peer 정보에 Task 정보 필드 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/example/main_server/evaluation/peer/dto/PeerInfoResponse.java

- Task 정보 필드 추가
- `TaskInfoResponse` 임포트 추가


</details>


  </td>
  <td><a href="https://github.com/LEADME-skala5/main_back_server/pull/9/files#diff-5e66607ee7c6609f3de2e7fad400f6443ae6bbc3c3f0349b64cc10eae872a93b">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>